### PR TITLE
refactor: remove tldts dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "request"
   ],
   "dependencies": {
-    "@metascraper/helpers": "~5.31.1",
+    "@metascraper/helpers": "~5.31.3",
     "cheerio": "~1.0.0-rc.12",
     "css-url-regex": "~4.0.0",
     "debug-logfmt": "~1.0.4",
     "execall": "~2.0.0",
     "got": "~11.8.5",
     "html-encode": "~2.1.6",
-    "html-urls": "~2.4.37",
+    "html-urls": "~2.4.39",
     "is-html-content": "~1.0.0",
     "lodash": "~4.17.21",
     "minimist": "~1.2.6",
@@ -44,8 +44,7 @@
     "p-retry": "~4.6.0",
     "replace-string": "~3.1.0",
     "time-span": "~4.0.0",
-    "tldts": "~5.7.89",
-    "top-sites": "~1.1.117",
+    "top-sites": "~1.1.132",
     "write-json-file": "~4.3.0"
   },
   "devDependencies": {
@@ -94,7 +93,6 @@
   },
   "license": "MIT",
   "ava": {
-    "workerThreads": false,
     "files": [
       "test/**/*.js",
       "!test/util.js"

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -3,10 +3,9 @@
 'use strict'
 
 const { compact, reduce, findIndex } = require('lodash')
+const { parseUrl } = require('@metascraper/helpers')
 const writeJsonFile = require('write-json-file')
 const topsites = require('top-sites')
-
-const { getDomainWithoutSuffix } = require('tldts')
 
 const domains = [
   'apple',
@@ -55,7 +54,7 @@ const { top, rest } = reduce(
   (acc, domain) => {
     const index = findIndex(
       topsites,
-      ({ rootDomain }) => getDomainWithoutSuffix(rootDomain) === domain
+      ({ rootDomain }) => parseUrl(rootDomain).domainWithoutSuffix === domain
     )
     if (index !== -1) acc.top[index] = domain
     else acc.rest.push(domain)

--- a/src/html.js
+++ b/src/html.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const { get, split, nth, castArray, forEach } = require('lodash')
+const { parseUrl } = require('@metascraper/helpers')
 const { TAGS: URL_TAGS } = require('html-urls')
 const replaceString = require('replace-string')
 const isHTML = require('is-html-content')
 const cssUrl = require('css-url-regex')
-const { getDomain } = require('tldts')
 const execall = require('execall')
 const cheerio = require('cheerio')
 const { URL } = require('url')
@@ -36,7 +36,7 @@ const addHead = ({ $, url, headers }) => {
   upsert(
     head.find('meta[property="og:site_name"]'),
     tags,
-    `<meta property="og:site_name" content="${getDomain(url)}">`
+    `<meta property="og:site_name" content="${parseUrl(url).domain}">`
   )
 
   if (date) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const { isMediaUrl } = require('@metascraper/helpers')
-const { getDomainWithoutSuffix } = require('tldts')
+const { parseUrl, isMediaUrl } = require('@metascraper/helpers')
 const debug = require('debug-logfmt')('html-get')
 const PCancelable = require('p-cancelable')
 const { AbortError } = require('p-retry')
@@ -122,7 +121,8 @@ const prerender = async (
 
 const modes = { fetch, prerender }
 
-const isFetchMode = url => autoDomains.includes(getDomainWithoutSuffix(url))
+const isFetchMode = url =>
+  autoDomains.includes(parseUrl(url).domainWithoutSuffix)
 
 const determinateMode = (url, { prerender }) => {
   if (prerender === false || isMediaUrl(url)) return 'fetch'


### PR DESCRIPTION
use `parseUrl` from @metascraper/helpers instead