### PR TITLE
feat: auto-prerender when shadow DOM detected in fetch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,6 +192,11 @@ const prerender = PCancelable.fn(
 
 const modes = { fetch, prerender }
 
+const hasShadowDOM = $ =>
+  $('*')
+    .toArray()
+    .some(el => el.tagName?.includes('-'))
+
 const isFetchMode = url => {
   const parsedUrl = parseUrl(url)
   return autoDomains.some(conditions =>
@@ -309,7 +314,24 @@ module.exports = PCancelable.fn(
 
     onCancel(() => promise.cancel())
 
-    const { mode, html, $, ...payload } = await promise
+    let { mode, html, $, ...payload } = await promise
+
+    if (mode === 'fetch' && getBrowserless && hasShadowDOM($)) {
+      debug('shadow DOM detected, retrying with prerender', { url: targetUrl })
+      const prerenderPromise = getContent(targetUrl, 'prerender', {
+        getBrowserless,
+        getTemporalFile,
+        gotOpts,
+        headers,
+        mutool,
+        puppeteerOpts,
+        rewriteUrls,
+        rewriteHtml,
+        toEncode
+      })
+      onCancel(() => prerenderPromise.cancel())
+      ;({ mode, html, $, ...payload } = await prerenderPromise)
+    }
 
     return Object.assign(payload, {
       ...serializeHtml($),

--- a/test/shadow-dom.js
+++ b/test/shadow-dom.js
@@ -50,3 +50,18 @@ test('shadow DOM content is flattened by default in prerender mode', async t => 
   t.true(html.includes('200'))
   t.true(html.includes('300'))
 })
+
+test('auto mode upgrades to prerender when shadow DOM is detected', async t => {
+  const url = await getUrl(t)
+  const result = await getHTML(url, {
+    prerender: 'auto',
+    getBrowserless: () => getBrowserContext(t),
+    puppeteerOpts: { adblock: false }
+  })
+
+  t.is(result.stats.mode, 'prerender')
+  const html = result.html
+  t.true(html.includes('Alice'))
+  t.true(html.includes('Bob'))
+  t.true(html.includes('Charlie'))
+})


### PR DESCRIPTION
Pages with custom elements render content in shadow roots that fetch mode can't serialize. Detect hyphenated tags in the fetched HTML and retry with prerender+flattenShadowDOM.