### PR TITLE
fix: include statusCode and redirects when both prerender and fetch fail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,9 @@ const prerender = PCancelable.fn(
           headers: data.headers || {},
           html: '',
           url,
-          mode: 'prerender'
+          mode: 'prerender',
+          statusCode: data.error?.response?.statusCode,
+          redirects: []
         }
       : data
   }


### PR DESCRIPTION
## Summary

- Adds missing `statusCode` and `redirects` fields to the response object when both prerender and fetch operations fail
- Ensures consistent API surface across all code paths in the `prerender` function

Closes #237

## Test plan

- [x] All 83 existing tests pass
- [x] Verified the fix matches the return shape of other error paths (`fetch` error at line 96-102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)