### PR TITLE
fix: respect explicit prerender:false over shadow DOM auto-upgrade

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -332,7 +332,12 @@ module.exports = PCancelable.fn(
 
     let shadowDOM = hasShadowDOM($)
 
-    if (mode === 'fetch' && getBrowserless && shadowDOM) {
+    if (
+      mode === 'fetch' &&
+      getBrowserless &&
+      shadowDOM &&
+      prerender !== false
+    ) {
       debug('shadow DOM detected, retrying with prerender', { url: targetUrl })
       const prerenderPromise = getContent(targetUrl, 'prerender', {
         getBrowserless,

--- a/test/shadow-dom.js
+++ b/test/shadow-dom.js
@@ -65,6 +65,20 @@ test('auto mode upgrades to prerender when shadow DOM is detected', async t => {
   t.true(html.includes('Charlie'))
 })
 
+test('explicit prerender:false is not upgraded despite shadow DOM', async t => {
+  const url = await getUrl(t)
+  const result = await getHTML(String(url), {
+    prerender: false,
+    getBrowserless: () => getBrowserContext(t),
+    puppeteerOpts: { adblock: false }
+  })
+
+  // shadow DOM is present but the explicit opt-out must win: no prerender retry
+  t.is(result.stats.mode, 'fetch')
+  t.true(result.stats.shadowDOM)
+  t.true(result.html.includes('<my-row'))
+})
+
 test('auto mode does not upgrade for SVG hyphenated tags', async t => {
   const url = await runServer(t, (_, res) => {
     res.setHeader('content-type', 'text/html')


### PR DESCRIPTION
The shadow DOM detector upgrades a fetch to prerender on any hyphenated tag, which over-triggers on sites full of custom elements (e.g. YouTube's polymer shell: ytd-app, yt-formatted-string). When a caller explicitly passes `prerender: false` it has opted out of rendering, so the auto upgrade must not override it — otherwise crawler-fetch domains get prerendered anyway and lose their server-rendered metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change to optional retry behavior plus a test; no auth or data-path changes.
> 
> **Overview**
> **Fixes shadow-DOM auto-upgrade ignoring `prerender: false`.** After a successful fetch, the library can retry with prerender when hyphenated custom elements look like shadow hosts. That retry now runs only when `prerender !== false`, so callers who explicitly opt out of rendering are not forced through the browser.
> 
> **Adds regression coverage** asserting that with `prerender: false`, `stats.mode` stays `fetch`, `stats.shadowDOM` is still true, and raw custom-element markup (e.g. `<my-row`) is preserved instead of flattened prerender output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515fd00efccc858562b3aadbbb01162f1f97eafc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->