### PR TITLE
feat(auto-domains): fetch-mode houzz to surface 429 block

### DIFF
--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -26,6 +26,7 @@ const domains = [
   [['domainWithoutSuffix', 'github']],
   [['domainWithoutSuffix', 'gitlab']],
   [['domainWithoutSuffix', 'google']],
+  [['domainWithoutSuffix', 'houzz']],
   [['domainWithoutSuffix', 'huffingtonpost']],
   [['domainWithoutSuffix', 'imdb']],
   [['domainWithoutSuffix', 'imgur']],

--- a/test/is-fetch-mode.js
+++ b/test/is-fetch-mode.js
@@ -10,6 +10,14 @@ test('true', t => {
       'https://www.abc.net.au/news/2023-06-14/idpwd-2023-calling-all-budding-storytellers-with-disability/102388090'
     )
   )
+  // houzz rate-limits datacenter IPs with a bare 429; fetch mode surfaces that
+  // status so is-antibot can flag it and escalate to the residential proxy,
+  // whereas prerender would return an empty shell that hides the block.
+  t.true(
+    isFetchMode(
+      'https://www.houzz.com/photos/primary-bathroom-retreat-transitional-bathroom-london-phvw-vp~210219633'
+    )
+  )
 })
 
 test('false', t => {


### PR DESCRIPTION
Houzz rate-limits datacenter IPs with a bare HTTP 429. Under prerender the headless browser returns an empty shell that hides the block, so is-antibot never sees it. Routing houzz through fetch mode surfaces the 429 status, letting is-antibot flag it (domain-scoped rule) and escalate to the proxy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small domain-list and test change; behavior is scoped to Houzz fetch routing with no auth or data-model impact.
> 
> **Overview**
> **Houzz** is added to the auto-domain list in `scripts/postinstall`, so Houzz URLs are handled in **fetch mode** instead of prerender after `auto-domains.json` is regenerated on install.
> 
> That change is intentional: Houzz often returns **HTTP 429** to datacenter IPs, and prerender can yield an empty page that hides the block. Fetch mode keeps the real status visible so **is-antibot** can detect the rate limit and escalate to the residential proxy. A test in `test/is-fetch-mode.js` locks in fetch mode for a sample Houzz photo URL, with a short comment explaining the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2abac378449c1273f573750b25f3c865429c45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->