### PR TITLE
build: upgrade html-urls to ~2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "execall": "~2.0.0",
     "got": "~11.8.6",
     "html-encode": "~2.1.15",
-    "html-urls": "~2.4.67",
+    "html-urls": "~2.5.0",
     "is-html-content": "~1.0.0",
     "is-local-address": "~2.3.4",
     "lodash": "~4.18.1",


### PR DESCRIPTION
Picks up [html-urls 2.5.0](https://github.com/Kikobeats/html-urls/pull/92), which stops `mailto:user@host` being rewritten into a fetchable `http://host` (via `@metascraper/helpers` 5.53.0).

Only `TAGS` is consumed here (`src/html.js:6`), and 2.5.0 ships no source change at all, so the tag map is identical. The upgrade is inert for this package beyond carrying the fix to anything resolving html-urls through it.

115 tests passing, lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump with no local code changes; intended behavior for `html-get` is unchanged aside from transitive URL-handling fixes.
> 
> **Overview**
> **Dependency-only change:** `html-urls` is upgraded from `~2.4.67` to `~2.5.0` in `package.json`; there are no application code changes in this repo.
> 
> This package only imports **`TAGS`** from `html-urls` (used in `rewriteHtmlUrls` in `src/html.js`). The release is described as unchanged for that API, so behavior here should stay the same while the newer version carries upstream fixes (notably avoiding incorrect rewriting of `mailto:user@host` into `http://host` via updated `@metascraper/helpers` in the dependency tree).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f19025b7ec987bab2c3590d15786982df52c7ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying HTML URL processing dependency to a newer compatible version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->