### PR TITLE
fix: fall back to fetch when prerender returns 4xx

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,6 +185,15 @@ const prerender = PCancelable.fn(
       )
 
       const payload = await getPayload(url, opts)
+      // page.content() succeeds on 4xx/5xx challenge pages; only cancel
+      // fetch when prerender is actually usable, otherwise keep a 2xx/3xx fetch.
+      if (payload.statusCode >= 400) {
+        const { isRejected, ...dataProps } = await fetchRes
+        if (!isRejected && dataProps.statusCode < 400) {
+          debug('prerender', { url, state: 'fallback', statusCode: payload.statusCode })
+          return dataProps
+        }
+      }
       await fetchRes.cancel()
       debug('prerender', { url, state: 'success' })
       return payload

--- a/test/mode.js
+++ b/test/mode.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { getBrowserContext, test } = require('./helpers')
+const { getBrowserContext, runServer, test } = require('./helpers')
 
 const getHTML = require('../src')
 
@@ -28,6 +28,61 @@ test("`{ prerender: 'auto' }`", async t => {
     puppeteerOpts: { adblock: false }
   })
   t.is(stats.mode, 'fetch')
+})
+
+test('prerender 4xx falls back to a successful fetch', async t => {
+  const url = await runServer(t, (_, res) => {
+    res.setHeader('content-type', 'text/html')
+    res.end('<!doctype html><title>About Us</title>')
+  })
+
+  const blockedBrowserless = () => ({
+    evaluate: () => async () => ({
+      headers: { 'content-type': 'text/html' },
+      html: '<html><title>ERROR: The request could not be satisfied</title></html>',
+      mode: 'prerender',
+      url: String(url),
+      statusCode: 403,
+      redirects: []
+    })
+  })
+
+  const { stats, html, statusCode } = await getHTML(String(url), {
+    prerender: true,
+    getBrowserless: blockedBrowserless
+  })
+
+  t.is(stats.mode, 'fetch')
+  t.is(statusCode, 200)
+  t.true(html.includes('About Us'))
+})
+
+test('prerender 4xx is kept when fetch is also unsuccessful', async t => {
+  const url = await runServer(t, (_, res) => {
+    res.statusCode = 403
+    res.setHeader('content-type', 'text/html')
+    res.end('<!doctype html><title>blocked</title>')
+  })
+
+  const blockedBrowserless = () => ({
+    evaluate: () => async () => ({
+      headers: { 'content-type': 'text/html' },
+      html: '<html><title>ERROR: The request could not be satisfied</title></html>',
+      mode: 'prerender',
+      url: String(url),
+      statusCode: 403,
+      redirects: []
+    })
+  })
+
+  const { stats, html, statusCode } = await getHTML(String(url), {
+    prerender: true,
+    getBrowserless: blockedBrowserless
+  })
+
+  t.is(stats.mode, 'prerender')
+  t.is(statusCode, 403)
+  t.true(html.includes('The request could not be satisfied'))
 })
 
 test.skip('prerender error fallback into fetch mode', async t => {


### PR DESCRIPTION
## Bug and impact

`prerender()` starts `got` and Chrome in parallel, then treats any `page.content()` as success and cancels fetch. A CloudFront/WAF 403 document is still a successful `page.content()`, so a parallel 200 fetch is dropped. That is how `https://www.un.org/en/about-us` kept the challenge page while `prerender=false` returned the real HTML.

## Root cause

Chrome success is defined as “got a document”, not “got a usable status”. Fetch is only used when Chrome throws.

## Fix

If prerender `statusCode >= 400`, wait for fetch. Use fetch when it is a 2xx/3xx. Otherwise keep the prerender document (both blocked, or fetch rejected).

## Validation

- `prerender 4xx falls back to a successful fetch` — mocked Chrome 403 + local 200 → `mode: fetch`, `statusCode: 200`
- `prerender 4xx is kept when fetch is also unsuccessful` — mocked Chrome 403 + local 403 → keep prerender 403
- `pnpm exec ava test/mode.js` passed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of prerendered pages returning client or server error statuses.
  * When available, the app now displays successfully fetched content instead of the prerendered error response.
  * Preserved prerendered error pages when the fallback fetch is unsuccessful.

* **Tests**
  * Added coverage for successful and unsuccessful fallback behavior, including response status, rendering mode, and displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->